### PR TITLE
Additional primitives: `sample`, `randn`, and `randexp`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Gen = "ea4f424c-a589-11e8-07c0-fd5c91b9da4a"
 IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 julia = "1.3"

--- a/src/Genify.jl
+++ b/src/Genify.jl
@@ -2,7 +2,7 @@ module Genify
 
 export genify
 
-using Gen, Distributions, Random
+using Gen, Distributions, StatsBase, Random
 using MacroTools, IRTools
 
 const Address = Union{Symbol, Pair{Symbol}}

--- a/src/Genify.jl
+++ b/src/Genify.jl
@@ -6,6 +6,8 @@ using Gen, Distributions, Random
 using MacroTools, IRTools
 
 const Address = Union{Symbol, Pair{Symbol}}
+const Setlike = Union{AbstractSet, AbstractDict}
+const Indexable = Union{AbstractArray, Tuple, AbstractString}
 
 include("transform.jl")
 include("distributions.jl")

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,5 +1,3 @@
-import StatsBase: sample
-
 "Wraps Distributions.jl distributions as Gen.jl distributions."
 struct WrappedDistribution{T,D <: Distributions.Distribution} <: Gen.Distribution{T}
     dist::D
@@ -110,46 +108,66 @@ Gen.has_argument_grads(::TypedArrayDistribution) =
     ()
 
 "Labeled uniform distribution over indexable collections."
-struct LabeledUniformDistribution{T} <: Gen.Distribution{T} end
-LabeledUniformDistribution() = LabeledUniformDistribution{Any}()
+struct LabeledUniform{T} <: Gen.Distribution{T} end
+LabeledUniform() = LabeledUniform{Any}()
 
-(d::LabeledUniformDistribution)(args...) = Gen.random(d, args...)
+(d::LabeledUniform)(args...) = Gen.random(d, args...)
 
-@inline Gen.random(::LabeledUniformDistribution{T}, labels::AbstractArray{T}) where {T} =
+@inline Gen.random(::LabeledUniform{T}, labels::AbstractArray{T}) where {T} =
     sample(labels)
-@inline Gen.random(::LabeledUniformDistribution{T}, labels::Tuple{Vararg{T}}) where {T} =
+@inline Gen.random(::LabeledUniform{T}, labels::Tuple{Vararg{T}}) where {T} =
     rand(labels)
-@inline Gen.random(::LabeledUniformDistribution{T}, labels::AbstractString) where {T <: AbstractChar} =
+@inline Gen.random(::LabeledUniform{T}, labels::AbstractString) where {T <: AbstractChar} =
     rand(labels)
-@inline Gen.logpdf(::LabeledUniformDistribution{T}, x::T, labels::Indexable) where {T} =
+@inline Gen.logpdf(::LabeledUniform{T}, x::T, labels::Indexable) where {T} =
     log(sum(x == l for l in labels) / length(labels))
 
-Gen.logpdf_grad(::LabeledUniformDistribution, x, labels) =
+Gen.logpdf_grad(::LabeledUniform, x, labels) =
     (nothing, nothing)
-Gen.has_output_grad(::LabeledUniformDistribution) =
+Gen.has_output_grad(::LabeledUniform) =
     false
-Gen.has_argument_grads(::LabeledUniformDistribution) =
+Gen.has_argument_grads(::LabeledUniform) =
     (nothing,)
 
 "Labeled uniform distribution over set-like collections."
-struct SetUniformDistribution{T} <: Gen.Distribution{T} end
-SetUniformDistribution() = SetUniformDistribution{Any}()
+struct SetUniform{T} <: Gen.Distribution{T} end
+SetUniform() = SetUniform{Any}()
 
-(d::SetUniformDistribution)(args...) = Gen.random(d, args...)
+(d::SetUniform)(args...) = Gen.random(d, args...)
 
-@inline Gen.random(::SetUniformDistribution{T}, support::AbstractSet{T}) where {T} =
+@inline Gen.random(::SetUniform{T}, support::AbstractSet{T}) where {T} =
     rand(support)
-@inline Gen.random(::SetUniformDistribution{Pair{T,U}}, support::AbstractDict{T,U}) where {T,U} =
+@inline Gen.random(::SetUniform{Pair{T,U}}, support::AbstractDict{T,U}) where {T,U} =
     rand(support)
 
-@inline Gen.logpdf(::SetUniformDistribution{T}, x::T, support::AbstractSet{T}) where {T} =
+@inline Gen.logpdf(::SetUniform{T}, x::T, support::AbstractSet{T}) where {T} =
     x in support ? -log(length(support)) : -Inf
-@inline Gen.logpdf(::SetUniformDistribution{Pair{T,U}}, x::Pair{T,U}, support::AbstractDict{T,U}) where {T,U} =
+@inline Gen.logpdf(::SetUniform{Pair{T,U}}, x::Pair{T,U}, support::AbstractDict{T,U}) where {T,U} =
     x in support ? -log(length(support)) : -Inf
 
-Gen.logpdf_grad(::SetUniformDistribution, x, support) =
+Gen.logpdf_grad(::SetUniform, x, support) =
     (nothing, nothing)
-Gen.has_output_grad(::SetUniformDistribution) =
+Gen.has_output_grad(::SetUniform) =
     false
-Gen.has_argument_grads(::SetUniformDistribution) =
+Gen.has_argument_grads(::SetUniform) =
+    (nothing,)
+
+"Categorical distribution over an array of labels."
+struct LabeledCategorical{T} <: Gen.Distribution{T} end
+LabeledCategorical() = LabeledCategorical{Any}()
+
+(d::LabeledCategorical)(args...) = Gen.random(d, args...)
+
+@inline Gen.random(::LabeledCategorical{T}, labels::AbstractArray{T}, weights::AbstractWeights) where {T} =
+    sample(labels, weights)
+@inline Gen.logpdf(::LabeledCategorical{T}, x::T, labels::AbstractArray{T}, weights::AbstractWeights) where {T} =
+    log(sum((x .== vec(labels)) .* Vector(weights)) / sum(weights))
+@inline Gen.logpdf(::LabeledCategorical{T}, x::T, labels::AbstractArray{T}, weights::UnitWeights) where {T} =
+    log(sum(x .== labels) / length(labels))
+
+Gen.logpdf_grad(::LabeledCategorical, x, labels) =
+    (nothing, nothing)
+Gen.has_output_grad(::LabeledCategorical) =
+    false
+Gen.has_argument_grads(::LabeledCategorical) =
     (nothing,)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -26,36 +26,24 @@ const randprims = Set([
     Gen.traceat(state, TypedArrayDistribution(T, d, dims...), (), addr)
 
 # rand for indexable collections
-const Indexable = Union{AbstractArray, AbstractRange, Tuple, AbstractString}
-flatten(c::Indexable) = c
-flatten(c::AbstractArray) = vec(c)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::Indexable) =
-    Gen.traceat(state, labeled_uniform, (flatten(c),), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::Indexable, ::Tuple{}) =
-    Gen.traceat(state, labeled_uniform, (flatten(c),), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::Indexable, dims::Dims) =
-    Gen.traceat(state, ArrayedDistribution(labeled_uniform, dims), (flatten(c),), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::Indexable, d::Integer, dims::Integer...) =
-    Gen.traceat(state, ArrayedDistribution(labeled_uniform, d, dims...), (flatten(c),), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T) where {T <: Indexable} =
+    Gen.traceat(state, LabeledUniformDistribution{eltype(T)}(), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T, ::Tuple{}) where {T <: Indexable} =
+    Gen.traceat(state, LabeledUniformDistribution{eltype(T)}(), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T, dims::Dims) where {T <: Indexable} =
+    Gen.traceat(state, ArrayedDistribution(LabeledUniformDistribution{eltype(T)}(), dims), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T, d::Integer, dims::Integer...) where {T <: Indexable} =
+    Gen.traceat(state, ArrayedDistribution(LabeledUniformDistribution{eltype(T)}(), d, dims...), (c,), addr)
 
 # rand for set-like collections
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractSet{T}) where {T} =
-    Gen.traceat(state, SetUniformDistribution{T}(), (c,), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractSet{T}, ::Tuple{}) where {T} =
-    Gen.traceat(state, SetUniformDistribution{T}(), (c,), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractSet{T}, dims::Dims) where {T} =
-    Gen.traceat(state, ArrayedDistribution(SetUniformDistribution{T}(), dims), (c,), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractSet{T}, d::Integer, dims::Integer...) where {T} =
-    Gen.traceat(state, ArrayedDistribution(SetUniformDistribution{T}(), d, dims...), (c,), addr)
-
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractDict{T,U}) where {T,U} =
-    Gen.traceat(state, SetUniformDistribution{Pair{T,U}}(), (c,), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractDict{T,U}, ::Tuple{}) where {T,U} =
-    Gen.traceat(state, SetUniformDistribution{Pair{T,U}}(), (c,), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractDict{T,U}, dims::Dims) where {T,U} =
-    Gen.traceat(state, ArrayedDistribution(SetUniformDistribution{Pair{T,U}}(), dims), (c,), addr)
-@inline trace(::Options, state, addr::Address, ::typeof(rand), c::AbstractDict{T,U}, d::Integer, dims::Integer...) where {T,U} =
-    Gen.traceat(state, ArrayedDistribution(SetUniformDistribution{Pair{T,U}}(), d, dims...), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T) where {T <: Setlike} =
+    Gen.traceat(state, SetUniformDistribution{eltype(T)}(), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T, ::Tuple{}) where {T <: Setlike} =
+    Gen.traceat(state, SetUniformDistribution{eltype(T)}(), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T, dims::Dims) where {T <: Setlike} =
+    Gen.traceat(state, ArrayedDistribution(SetUniformDistribution{eltype(T)}(), dims), (c,), addr)
+@inline trace(::Options, state, addr::Address, ::typeof(rand), c::T, d::Integer, dims::Integer...) where {T <: Setlike} =
+    Gen.traceat(state, ArrayedDistribution(SetUniformDistribution{eltype(T)}(), d, dims...), (c,), addr)
 
 # rand for Distributions.jl distributions
 @inline trace(::Options, state, addr::Address, ::typeof(rand), dist::D) where {D <: Distributions.Distribution} =

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -1,3 +1,5 @@
+@testset "Random primitives" begin
+
 @testset "rand(::Type{<:Integer}) statements" begin
 
 function foo(n::Int)
@@ -199,5 +201,7 @@ trace, weight = generate(genfoo, (), choicemap(:a => 1, :b => 1))
 @test weight ≈ Gen.logpdf(normal, 0, 1, 1) + Gen.logpdf(exponential, 1, 1)
 trace, weight = generate(genfoo, (10,), choicemap(:c => ones(10), :d => ones(10)))
 @test weight ≈ 10 * (Gen.logpdf(normal, 0, 1, 1) + Gen.logpdf(exponential, 1, 1))
+
+end
 
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -168,7 +168,7 @@ trace, weight = generate(genfoo, (10, 10), choicemap(:d => zeros(10, 10)))
 
 end
 
-@testset "randn and randexp statements" begin
+@testset "randn() and randexp() statements" begin
 
 function foo(dims...)
     a = randn()
@@ -201,6 +201,36 @@ trace, weight = generate(genfoo, (), choicemap(:a => 1, :b => 1))
 @test weight ≈ Gen.logpdf(normal, 0, 1, 1) + Gen.logpdf(exponential, 1, 1)
 trace, weight = generate(genfoo, (10,), choicemap(:c => ones(10), :d => ones(10)))
 @test weight ≈ 10 * (Gen.logpdf(normal, 0, 1, 1) + Gen.logpdf(exponential, 1, 1))
+
+end
+
+@testset "sample() statements" begin
+
+function foo()
+    a = sample([:h, :e, :l, :l, :o], weights([1, 1, 5, 1, 1]))
+    b = sample(collect("world"), (10, 10))
+end
+
+genfoo = genify(foo)
+
+# Check types
+trace = simulate(genfoo, ())
+@test trace[:a] isa Symbol
+@test trace[:b] isa Matrix{Char}
+
+# Test array sizes
+trace = simulate(genfoo, ())
+@test size(trace[:b]) == (10, 10)
+
+# Test ranges
+@test trace[:a] in [:h, :e, :l, :l, :o]
+@test all(x in "world" for x in trace[:b])
+
+# Test generate with constraints
+trace, weight = generate(genfoo, (), choicemap(:a => :l))
+@test weight ≈ log(6/9)
+trace, weight = generate(genfoo, (), choicemap(:b => fill('w', (10, 10))))
+@test weight ≈ log(1/5) * 100
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, Genify
-using Random, Distributions, Gen
+using Random, StatsBase, Distributions, Gen
 
 include("transform.jl")
 include("primitives.jl")


### PR DESCRIPTION
Also fixes a bug that occurred when genifying parametric methods.